### PR TITLE
Fix url for clone endpoint

### DIFF
--- a/libs/lume/docs/API-Reference.md
+++ b/libs/lume/docs/API-Reference.md
@@ -181,7 +181,7 @@ curl --connect-timeout 6000 \
     "name": "source-vm",
     "newName": "cloned-vm"
   }' \
-  http://localhost:3000/lume/vms/source-vm/clone
+  http://localhost:3000/lume/vms/clone
 ```
 </details>
 


### PR DESCRIPTION
Looks like the url was incorrect in the API docs.

## Not working

```bash
curl --connect-timeout 6000 \
  --max-time 5000 \
  -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "name": "macos-sequoia-vanilla_latest",
    "newName": "cloned-vm"
  }' \
  http://localhost:3000/lume/vms/macos-sequoia-vanilla_latest/clone
Not found%
```

## Working

```bash
curl --connect-timeout 6000 \
  --max-time 5000 \
  -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "name": "macos-sequoia-vanilla_latest",
    "newName": "cloned-vm"
  }' \
  http://localhost:3000/lume/vms/clone
{"message":"VM cloned successfully","source":"macos-sequoia-vanilla_latest","destination":"cloned-vm"}%
```

TODO for later: It would great to add auto-generated docs via something like swagger.